### PR TITLE
Make the plugin JCasC compliant

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <relativePath />
   </parent>
   <artifactId>strict-crumb-issuer</artifactId>
-  <version>2.0.2-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <properties>

--- a/src/main/java/org/jenkinsci/plugins/strictcrumbissuer/StrictCrumbIssuer.java
+++ b/src/main/java/org/jenkinsci/plugins/strictcrumbissuer/StrictCrumbIssuer.java
@@ -179,14 +179,14 @@ public class StrictCrumbIssuer extends CrumbIssuer {
         this.initMessageDigest();
     }
 
-    private synchronized Object readResolve() {
+    private Object readResolve() {
         this.ensureHoursValidIsInBoundaries();
         this.initMessageDigest();
 
         return this;
     }
 
-    private void initMessageDigest(){
+    private synchronized void initMessageDigest(){
         try {
             this.md = MessageDigest.getInstance(MD_NAME);
         } catch (NoSuchAlgorithmException e) {

--- a/src/main/java/org/jenkinsci/plugins/strictcrumbissuer/StrictCrumbIssuer.java
+++ b/src/main/java/org/jenkinsci/plugins/strictcrumbissuer/StrictCrumbIssuer.java
@@ -26,17 +26,19 @@ package org.jenkinsci.plugins.strictcrumbissuer;
 import com.google.common.net.HttpHeaders;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
+import hudson.RestrictedSince;
 import hudson.Util;
 import hudson.model.ModelObject;
 import hudson.security.csrf.CrumbIssuer;
 import hudson.security.csrf.CrumbIssuerDescriptor;
 import jenkins.model.Jenkins;
 import jenkins.security.HexStringConfidentialKey;
-import jenkins.util.SystemProperties;
 import net.sf.json.JSONObject;
 import org.acegisecurity.Authentication;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -169,8 +171,10 @@ public class StrictCrumbIssuer extends CrumbIssuer {
         this.xorMasking = xorMasking;
     }
 
+    // only set public for JCasC as they do not currently support private methods for PostConstruct
+    @Restricted(NoExternalUse.class)
     @PostConstruct
-    private void setup(){
+    public void setup(){
         this.ensureHoursValidIsInBoundaries();
         this.initMessageDigest();
     }
@@ -202,28 +206,68 @@ public class StrictCrumbIssuer extends CrumbIssuer {
         }
     }
 
+    /**
+     * @deprecated name was changed for JCasC, please use isCheckClientIP instead
+     */
+    @Deprecated
+    @RestrictedSince("2.1.0")
+    @Restricted(NoExternalUse.class)
     public boolean isCheckingClientIP() {
         return this.checkClientIP;
     }
 
+    /**
+     * @deprecated name was changed for JCasC, please use isCheckSameSource instead
+     */
+    @Deprecated
+    @RestrictedSince("2.1.0")
+    @Restricted(NoExternalUse.class)
     public boolean isCheckingSameSource() {
         return this.checkSameSource;
     }
 
+    /**
+     * @deprecated name was changed for JCasC, please use isCheckOnlyLocalPath instead
+     */
+    @Deprecated
+    @RestrictedSince("2.1.0")
+    @Restricted(NoExternalUse.class)
     public boolean isCheckingOnlyLocalPath() {
         return this.checkOnlyLocalPath;
     }
 
+    /**
+     * @deprecated name was changed for JCasC, please use isCheckSessionMatch instead
+     */
+    @Deprecated
+    @RestrictedSince("2.1.0")
+    @Restricted(NoExternalUse.class)
     public boolean isCheckingSessionMatch() {
         return this.checkSessionMatch;
     }
 
+    public boolean isCheckClientIP() {
+        return this.checkClientIP;
+    }
+
+    public boolean isCheckSameSource() {
+        return this.checkSameSource;
+    }
+
+    public boolean isCheckOnlyLocalPath() {
+        return this.checkOnlyLocalPath;
+    }
+
+    public boolean isCheckSessionMatch() {
+        return this.checkSessionMatch;
+    }
+
     public int getHoursValid() {
-        return hoursValid;
+        return this.hoursValid;
     }
 
     public boolean isXorMasking() {
-        return xorMasking;
+        return this.xorMasking;
     }
 
     @Override
@@ -298,8 +342,8 @@ public class StrictCrumbIssuer extends CrumbIssuer {
     }
 
     private @CheckForNull String urlForCreation(@Nonnull HttpServletRequest req){
-        if(isCheckingSameSource()){
-            if(isCheckingOnlyLocalPath()){
+        if(isCheckSameSource()){
+            if(isCheckOnlyLocalPath()){
                 String contextPath = req.getContextPath();
                 String requestURI = req.getRequestURI();
                 if (!requestURI.startsWith(contextPath)) {
@@ -330,14 +374,14 @@ public class StrictCrumbIssuer extends CrumbIssuer {
     }
 
     private @CheckForNull String urlForValidation(@Nonnull HttpServletRequest req){
-        if(isCheckingSameSource()){
+        if(isCheckSameSource()){
             String referer = req.getHeader(HttpHeaders.REFERER);
             if(referer == null){
                 LOGGER.log(Level.WARNING, "No referer present in the request, perhaps it is better to check only local path");
                 return null;
             }
 
-            if(isCheckingOnlyLocalPath()){
+            if(isCheckOnlyLocalPath()){
                 URL url;
                 try {
                     url = new URL(referer);
@@ -371,7 +415,7 @@ public class StrictCrumbIssuer extends CrumbIssuer {
         builder.append(a.getName());
         builder.append(';');
 
-        if (isCheckingClientIP()) {
+        if (isCheckClientIP()) {
             builder.append(getClientIP(req));
             builder.append(';');
         }
@@ -381,7 +425,7 @@ public class StrictCrumbIssuer extends CrumbIssuer {
             builder.append(';');
         }
 
-        if (isCheckingSessionMatch()) {
+        if (isCheckSessionMatch()) {
             builder.append(req.getSession().getId());
             builder.append(';');
         }

--- a/src/main/resources/org/jenkinsci/plugins/strictcrumbissuer/StrictCrumbIssuer/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/strictcrumbissuer/StrictCrumbIssuer/config.jelly
@@ -29,19 +29,19 @@ THE SOFTWARE.
 
     <f:advanced>
         <f:entry title="" field="checkSessionMatch">
-            <f:checkbox checked="${instance.isCheckingSessionMatch()}" default="true" title="${%checkSessionId}"/>
+            <f:checkbox checked="${instance.isCheckSessionMatch()}" default="true" title="${%checkSessionId}"/>
         </f:entry>
         <f:entry title="" field="xorMasking">
             <f:checkbox checked="${instance.isXorMasking()}" default="true" title="${%xorMasking}" />
         </f:entry>
         <f:entry title="" field="checkClientIP">
-            <f:checkbox checked="${instance.isCheckingClientIP()}" default="false" title="${%checkClientIp}" />
+            <f:checkbox checked="${instance.isCheckClientIP()}" default="false" title="${%checkClientIp}" />
         </f:entry>
         <f:entry title="" field="checkSameSource">
-            <f:checkbox checked="${instance.isCheckingSameSource()}" default="false" title="${%checkSameSource}" />
+            <f:checkbox checked="${instance.isCheckSameSource()}" default="false" title="${%checkSameSource}" />
         </f:entry>
         <f:entry title="" field="checkOnlyLocalPath">
-            <f:checkbox checked="${instance.isCheckingOnlyLocalPath()}" default="false" title="${%checkOnlyLocalPath}" />
+            <f:checkbox checked="${instance.isCheckOnlyLocalPath()}" default="false" title="${%checkOnlyLocalPath}" />
         </f:entry>
     </f:advanced>
 </j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/strictcrumbissuer/StrictCrumbIssuerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/strictcrumbissuer/StrictCrumbIssuerTest.java
@@ -433,24 +433,24 @@ public class StrictCrumbIssuerTest {
         wc.login("foo");
 
         configureIssuerUsingWebUI(wc, true, null, null, null, null, null);
-        assertEquals(true, currentIssuer().isCheckingClientIP());
+        assertEquals(true, currentIssuer().isCheckClientIP());
         configureIssuerUsingWebUI(wc, false, null, null, null, null, null);
-        assertEquals(false, currentIssuer().isCheckingClientIP());
+        assertEquals(false, currentIssuer().isCheckClientIP());
 
         configureIssuerUsingWebUI(wc, null, true, null, null, null, null);
-        assertEquals(true, currentIssuer().isCheckingSameSource());
+        assertEquals(true, currentIssuer().isCheckSameSource());
         configureIssuerUsingWebUI(wc, null, false, null, null, null, null);
-        assertEquals(false, currentIssuer().isCheckingSameSource());
+        assertEquals(false, currentIssuer().isCheckSameSource());
 
         configureIssuerUsingWebUI(wc, null, null, true, null, null, null);
-        assertEquals(true, currentIssuer().isCheckingOnlyLocalPath());
+        assertEquals(true, currentIssuer().isCheckOnlyLocalPath());
         configureIssuerUsingWebUI(wc, null, null, false, null, null, null);
-        assertEquals(false, currentIssuer().isCheckingOnlyLocalPath());
+        assertEquals(false, currentIssuer().isCheckOnlyLocalPath());
 
         configureIssuerUsingWebUI(wc, null, null, null, true, null, null);
-        assertEquals(true, currentIssuer().isCheckingSessionMatch());
+        assertEquals(true, currentIssuer().isCheckSessionMatch());
         configureIssuerUsingWebUI(wc, null, null, null, false, null, null);
-        assertEquals(false, currentIssuer().isCheckingSessionMatch());
+        assertEquals(false, currentIssuer().isCheckSessionMatch());
 
         configureIssuerUsingWebUI(wc, null, null, null, null, null, true);
         assertEquals(true, currentIssuer().isXorMasking());


### PR DESCRIPTION
The problems were:
- Some getters were not following basic POJO rules
- The PostConstruct on private method is supported by the JavaDoc of the annotation but not yet by JCasC

The first point resulted in the plugin not being fully configurable and the second one to crash the instance once setup.

@daniel-beck @ewelinawilkosz 