### PR TITLE
[JENKINS-70797] Less verbose and improved logs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/strictcrumbissuer/StrictCrumbIssuer.java
+++ b/src/main/java/org/jenkinsci/plugins/strictcrumbissuer/StrictCrumbIssuer.java
@@ -30,6 +30,7 @@ import hudson.Extension;
 import hudson.RestrictedSince;
 import hudson.Util;
 import hudson.model.ModelObject;
+import hudson.model.User;
 import hudson.security.csrf.CrumbIssuer;
 import hudson.security.csrf.CrumbIssuerDescriptor;
 import java.math.BigInteger;
@@ -56,6 +57,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 
 public class StrictCrumbIssuer extends CrumbIssuer {
@@ -319,7 +321,8 @@ public class StrictCrumbIssuer extends CrumbIssuer {
                         }
                     }
                 }
-                LOGGER.log(Level.INFO, "Invalid crumb found in the request");
+                Level level = Jenkins.getAuthentication2() instanceof AnonymousAuthenticationToken ? Level.FINE : Level.WARNING;
+                LOGGER.log(level, "Invalid crumb found in the request from user " + User.current() + " at path " + req.getPathInfo());
             } else {
                 LOGGER.log(Level.FINER, "No crumb available in the request");
             }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-70797

Adapting the logs level in case the session is expired, to make less noise in this case. 
Also improving the message to make it useful.
### Testing done

I only tried locally that in case of expired session, the level change properly.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- X ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- N/A Link to relevant pull requests, esp. upstream and downstream changes
- NLA Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
